### PR TITLE
Add ACEROUTINE_SUPPRESS_UNTESTED_PLATFORM

### DIFF
--- a/src/ace_routine/compat.h
+++ b/src/ace_routine/compat.h
@@ -75,7 +75,9 @@ class __FlashStringHelper;
   #include <pgmspace.h>
 
 #else
+  #ifndef ACEROUTINE_SUPPRESS_UNTESTED_PLATFORM
   #warning Untested platform, AceRoutine may still work...
+  #endif
 
   #include <avr/pgmspace.h>
   #ifndef FPSTR


### PR DESCRIPTION
Allows suppressing the "untested platform" warning when using on a non-traditional platform, by defining the macro before importing AceRoutine.