### PR TITLE
Avoid micros() clashing with micros() macro expansion in esphome.

### DIFF
--- a/src/ace_routine/ClockInterface.h
+++ b/src/ace_routine/ClockInterface.h
@@ -40,10 +40,10 @@ namespace ace_routine {
 class ClockInterface {
   public:
     /** Get the current millis. */
-    static unsigned long millis() { return ::millis(); }
+    static unsigned long (millis)() { return ::millis(); }
 
     /** Get the current micros. */
-    static unsigned long micros() { return ::micros(); }
+    static unsigned long (micros)() { return ::micros(); }
 
     /**
      * Get the current seconds. This is derived by dividing millis() by 1000,


### PR DESCRIPTION
I understand this is an awkward proposal, but this is the easiest path I see for this library to be supported for development on top of esphome and other frameworks that define micros() using a macro.

I see a slight reduction in readability of this header but a win in that it becomes drop-in usable with esphome development.